### PR TITLE
Fix low real time factor

### DIFF
--- a/gilbreth_application/launch/application_setup.launch
+++ b/gilbreth_application/launch/application_setup.launch
@@ -8,6 +8,8 @@
   <arg name="rviz" default = "false"/>
   <arg name="headless" default="false"/>
   <arg name="debug" default="false"/>
+  <arg name="physics" default="ode"/>
+  
   <arg name="extra_gazebo_args" default="--verbose"/>
 
   <!-- gazebo and moveit -->
@@ -18,6 +20,7 @@
     <arg name="use_sim_time" value="$(arg use_sim_time)"/>
     <arg name="headless" value="$(arg headless)"/>
     <arg name="extra_gazebo_args" value="$(arg extra_gazebo_args)"/>
+    <arg name="physics" default="$(arg physics)"/>
     <arg name="rviz" default = "$(arg rviz)"/>
   </include>
 

--- a/gilbreth_application/scripts/run.sh
+++ b/gilbreth_application/scripts/run.sh
@@ -2,7 +2,7 @@
 echo "Start Demo"
 echo "Moving Conveyor Belt"
 rosservice call /gilbreth/conveyor/control "state:
-  power: 100.0" 
+  power: 20.0" 
 echo "Start Spawning Objects"
 rosservice call /start_spawn
 echo "Start kinect_publisher"

--- a/gilbreth_gazebo/CMakeLists.txt
+++ b/gilbreth_gazebo/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   std_srvs
   tf
+  eigen_conversions
 )
 
 find_package(gazebo REQUIRED)
@@ -129,6 +130,7 @@ set(side_contact_plugin_name SideContactPlugin)
 add_library(${side_contact_plugin_name} src/plugins/SideContactPlugin.cc)
 target_link_libraries(${side_contact_plugin_name}
   ${GAZEBO_LIBRARIES}
+  ${catkin_LIBRARIES}
 )
 #install(TARGETS ${side_contact_plugin_name}
 #  ARCHIVE DESTINATION lib
@@ -230,6 +232,7 @@ add_library(${object_disposal_plugin_name} src/plugins/ObjectDisposalPlugin.cc)
 target_link_libraries(${object_disposal_plugin_name}
   ${GAZEBO_LIBRARIES}
   ${side_contact_plugin_name}
+  ${catkin_LIBRARIES}
 )
 #install(TARGETS ${object_disposal_plugin_name}
 #  ARCHIVE DESTINATION lib

--- a/gilbreth_gazebo/config/conveyor_objects.yaml
+++ b/gilbreth_gazebo/config/conveyor_objects.yaml
@@ -2,6 +2,7 @@ spawner:
   reference_frame: world            # Gazebo frame in which to spawn the parts
   spawn_period: 15.0                 # [s] Time between component spawnings
   randomization_seed: 0             # Seed for randomization engine
+  max_objects: 40                   # Max number of objects to spawn, objects will be recycled after max is reached.
   objects:
     - name: gear                        # Name of the spawned object
       mesh_resource: package://gilbreth_gazebo/meshes/conveyor_objects/gear.stl

--- a/gilbreth_gazebo/include/gilbreth_gazebo/conveyor_spawner.h
+++ b/gilbreth_gazebo/include/gilbreth_gazebo/conveyor_spawner.h
@@ -6,6 +6,7 @@
 #include <std_srvs/Empty.h>
 #include <urdf/model.h>
 #include <XmlRpcValue.h>
+#include <gazebo_msgs/ModelStates.h>
 
 namespace gilbreth
 {
@@ -27,6 +28,7 @@ struct SpawnParameters
   std::string reference_frame;
   double spawn_period;
   int randomization_seed;
+  int max_objects = 40;                   /** @brief maximum number of objects to spawn, objects will then be recycled */
   std::vector<ObjectParameters> objects;
 };
 
@@ -62,17 +64,25 @@ private:
             std_srvs::EmptyResponse& res);
 
 
-  void spawnObject(const ros::TimerEvent& e);
+  void spawnObjectTimerCb(const ros::TimerEvent& e);
+  void spawnObject();
+  void recirculateObject();
+
+  void disposedObjectsCallback(const gazebo_msgs::ModelStatesConstPtr& msg);
 
 
   int object_counter_ = 0;
   ros::NodeHandle nh_;
   ros::Publisher pub_;
+  ros::Subscriber disposed_objs_subs_;
   ros::ServiceClient spawn_client_;
+  ros::ServiceClient set_state_client_;
   ros::ServiceServer start_server_;
   ros::ServiceServer stop_server_;
   ros::Timer timer_;
   SpawnParameters params_;
+  std::vector<std::string> inactive_objects_ids_;
+  std::map<std::string,std::string> spawned_objects_map_; /** @brief mapping between object names and models used <obj_id, obj_name>*/
 
 };
 

--- a/gilbreth_gazebo/include/gilbreth_gazebo/plugins/ConveyorBeltPlugin.hh
+++ b/gilbreth_gazebo/include/gilbreth_gazebo/plugins/ConveyorBeltPlugin.hh
@@ -160,7 +160,7 @@ namespace gazebo
     private: math::Angle limit;
 
     /// \brief Maximum linear velocity of the belt.
-    private: const double kMaxBeltLinVel = 0.2;
+    private: double kMaxBeltLinVel = 0.4;
 
     /// \brief Gazebo node for communication.
     protected: transport::NodePtr gzNode;

--- a/gilbreth_gazebo/include/gilbreth_gazebo/plugins/ObjectDisposalPlugin.hh
+++ b/gilbreth_gazebo/include/gilbreth_gazebo/plugins/ObjectDisposalPlugin.hh
@@ -80,6 +80,12 @@ public:
     return ref != queue_.end();
   }
 
+  std::size_t size()
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return queue_.size();
+  }
+
 private:
 
   std::list<T> queue_;
@@ -116,7 +122,7 @@ namespace gazebo
     /**
      * @brief Calls the service to delete models
      */
-    void deleteQueuedObjects();
+    void publishDeactivatedObjects();
 
     /// \brief If true, only delete models if their CoG is within the bounding box of the link
     protected: bool centerOfGravityCheck;
@@ -129,9 +135,8 @@ namespace gazebo
     std::shared_ptr<ros::NodeHandle> nh_;
     ros::CallbackQueue ros_queue_;
     std::thread ros_queue_thread_;
-    ros::ServiceClient delete_model_client_;
-    ros::ServiceClient set_state_client_;
-    ConcurrentQueue<std::string> delete_model_queue_;
+    ros::Publisher disposed_models_pub_;
+    ConcurrentQueue<std::string> disposed_models_queue_;
     std::string world_frame_id_;
 
   };

--- a/gilbreth_gazebo/include/gilbreth_gazebo/plugins/ObjectDisposalPlugin.hh
+++ b/gilbreth_gazebo/include/gilbreth_gazebo/plugins/ObjectDisposalPlugin.hh
@@ -25,8 +25,66 @@
 #include <gazebo/math/Pose.hh>
 #include <gazebo/sensors/sensors.hh>
 #include <gazebo/util/system.hh>
+#include <ros/node_handle.h>
+#include <ros/service_client.h>
+#include <ros/callback_queue.h>
+#include <gazebo_msgs/DeleteModel.h>
+#include <gazebo_msgs/SetModelState.h>
+#include <thread>
+#include <queue>
 
 #include "SideContactPlugin.hh"
+
+template <typename T>
+class ConcurrentQueue
+{
+public:
+  ConcurrentQueue()
+  {
+
+  }
+
+  ~ConcurrentQueue()
+  {
+
+  }
+
+  void pop()
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    queue_.pop_front();
+  }
+
+  T front()
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return queue_.front();
+  }
+
+  bool empty()
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return queue_.empty();
+  }
+
+  void push(const T& e)
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    queue_.push_back(e);
+  }
+
+  bool hasEntry(const T& e)
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto ref = std::find(queue_.begin(),queue_.end(),e);
+    return ref != queue_.end();
+  }
+
+private:
+
+  std::list<T> queue_;
+  std::mutex mutex_;
+};
 
 namespace gazebo
 {
@@ -50,11 +108,32 @@ namespace gazebo
     /// \brief Act on models that are ontop of the sensor's link
     protected: void ActOnContactingModels();
 
+    /**
+     * @brief Callback that processes ROS related events
+     */
+    protected: void processROSQueue();
+
+    /**
+     * @brief Calls the service to delete models
+     */
+    void deleteQueuedObjects();
+
     /// \brief If true, only delete models if their CoG is within the bounding box of the link
     protected: bool centerOfGravityCheck;
 
     /// \brief Pose where the object will be teleported.
-    protected: math::Pose disposalPose;
+    protected: math::Pose disposalPose; // TODO: Remove this seemingly unused member.
+
+    protected:
+    // ROS Connection
+    std::shared_ptr<ros::NodeHandle> nh_;
+    ros::CallbackQueue ros_queue_;
+    std::thread ros_queue_thread_;
+    ros::ServiceClient delete_model_client_;
+    ros::ServiceClient set_state_client_;
+    ConcurrentQueue<std::string> delete_model_queue_;
+    std::string world_frame_id_;
+
   };
 }
 #endif

--- a/gilbreth_gazebo/launch/gilbreth_environment.launch
+++ b/gilbreth_gazebo/launch/gilbreth_environment.launch
@@ -22,7 +22,9 @@
   </include>
 
   <!-- Load the URDF into the ROS Parameter Server -->
-  <include file="$(find gilbreth_moveit_config)/launch/move_group.launch"/>
+  <include file="$(find gilbreth_moveit_config)/launch/move_group.launch">
+    <arg name="console_output" value="false"/>
+  </include>
   <include file="$(find gilbreth_support)/launch/load_gilbreth.launch"/>
 
   <!-- Spawn the URDF objects into Gazebo -->

--- a/gilbreth_gazebo/launch/gilbreth_environment.launch
+++ b/gilbreth_gazebo/launch/gilbreth_environment.launch
@@ -8,6 +8,7 @@
   <arg name="rviz" default = "false"/>
   <arg name="headless" default="false"/>
   <arg name="debug" default="false"/>
+  <arg name="physics" default="ode"/>
   <arg name="extra_gazebo_args" default="--verbose"/>
 
   <!-- We resume the logic in empty_world.launch, changing only the name of the world to be launched -->
@@ -19,6 +20,7 @@
     <arg name="use_sim_time" value="$(arg use_sim_time)"/>
     <arg name="headless" value="$(arg headless)"/>
     <arg name="extra_gazebo_args" value="$(arg extra_gazebo_args)"/>
+    <arg name="physics" default="$(arg physics)"/>
   </include>
 
   <!-- Load the URDF into the ROS Parameter Server -->

--- a/gilbreth_gazebo/models/conveyor/model.sdf
+++ b/gilbreth_gazebo/models/conveyor/model.sdf
@@ -85,6 +85,7 @@
       <robot_namespace>/gilbreth</robot_namespace>
       <population_rate_modifier_topic>/gilbreth/population/rate_modifier</population_rate_modifier_topic>
       <link>conveyor_belt::conveyor_belt_moving::belt</link>
+      <max_belt_linear_vel>1.0</max_belt_linear_vel>
       <power>0</power>
     </plugin>
 

--- a/gilbreth_gazebo/models/deletion_wall/model.sdf
+++ b/gilbreth_gazebo/models/deletion_wall/model.sdf
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?>
+<?xml version="1.0"?>
 <sdf version="1.6">
   <model name="deletion_wall">
     <!-- add a link that is sensing collisions -->

--- a/gilbreth_gazebo/package.xml
+++ b/gilbreth_gazebo/package.xml
@@ -23,6 +23,7 @@
   <depend>std_srvs</depend>
   <depend>tinyxml</depend>
   <depend>tf</depend>
+  <depend>eigen_conversions</depend>
 
   <build_depend>message_generation</build_depend>
 
@@ -31,7 +32,6 @@
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>ur_description</exec_depend>
-  <exec_depend>rviz</exec_depend>
 
   <export>
     <gazebo_ros plugin_path="${prefix}/lib" />

--- a/gilbreth_gazebo/src/conveyor_spawner.cpp
+++ b/gilbreth_gazebo/src/conveyor_spawner.cpp
@@ -1,17 +1,26 @@
 #include <boost/filesystem.hpp>
 #include <gazebo_msgs/SpawnModel.h>
+#include <gazebo_msgs/SetModelState.h>
 #include "gilbreth_gazebo/conveyor_spawner.h"
 #include "gilbreth_gazebo/urdf_creator.h"
 #include <random>
 #include <ros/package.h>
 #include <XmlRpcException.h>
 #include <tf/transform_datatypes.h>
+#include <boost/format.hpp>
 
 const static std::string GAZEBO_SPAWN_SERVICE = "gazebo/spawn_urdf_model";
 const static std::string START_SPAWN_SERVICE = "start_spawn";
 const static std::string STOP_SPAWN_SERVICE = "stop_spawn";
 const static std::string SPAWNED_PART_TOPIC = "spawned_part";
+static const std::string GAZEBO_SET_MODEL_STATE_SERVICE = "gazebo/set_model_state";
+static const std::string GAZEBO_DISPOSED_MODELS_TOPIC = "gazebo/disposed_models";
 const static double SRV_TIMEOUT = 10.0f;
+
+std::string generateObjectName(int id)
+{
+  return "object_" + std::to_string(id);
+}
 
 namespace gilbreth
 {
@@ -42,7 +51,7 @@ bool ConveyorSpawner::init(XmlRpc::XmlRpcValue& p)
 
   start_server_ = nh_.advertiseService(START_SPAWN_SERVICE, &ConveyorSpawner::start, this);
   stop_server_ = nh_.advertiseService(STOP_SPAWN_SERVICE, &ConveyorSpawner::stop, this);
-  timer_ = nh_.createTimer(ros::Duration(params_.spawn_period), &ConveyorSpawner::spawnObject, this, false, false);
+  timer_ = nh_.createTimer(ros::Duration(params_.spawn_period), &ConveyorSpawner::spawnObjectTimerCb, this, false, false);
   pub_ = nh_.advertise<std_msgs::Header>(SPAWNED_PART_TOPIC, 10, true);
 
   return true;
@@ -72,6 +81,10 @@ bool ConveyorSpawner::loadSpawnParameters(const XmlRpc::XmlRpcValue& p,
     // Get the randomization seed
     XmlRpc::XmlRpcValue& seed = params["randomization_seed"];
     spawn_params.randomization_seed = static_cast<int>(seed);
+
+    // Get max objects
+    XmlRpc::XmlRpcValue& max_objects = params["max_objects"];
+    spawn_params.max_objects = static_cast<int>(max_objects);
 
     // Get the spawned objects
     XmlRpc::XmlRpcValue& objects = params["objects"];
@@ -155,6 +168,16 @@ bool ConveyorSpawner::connectToROS()
     return false;
   }
 
+  set_state_client_ = nh_.serviceClient<gazebo_msgs::SetModelState>(GAZEBO_SET_MODEL_STATE_SERVICE);
+  if(!set_state_client_.waitForExistence(ros::Duration(SRV_TIMEOUT)))
+  {
+    ROS_ERROR("Timeout waiting for '%s' service", set_state_client_.getService().c_str());
+    return false;
+  }
+
+  disposed_objs_subs_ = nh_.subscribe<gazebo_msgs::ModelStates>(GAZEBO_DISPOSED_MODELS_TOPIC,1,
+                                                                   &ConveyorSpawner::disposedObjectsCallback,this);
+
   return true;
 }
 
@@ -174,7 +197,19 @@ bool ConveyorSpawner::stop(std_srvs::EmptyRequest& req,
   return true;
 }
 
-void ConveyorSpawner::spawnObject(const ros::TimerEvent& e)
+void ConveyorSpawner::spawnObjectTimerCb(const ros::TimerEvent& e)
+{
+  if(object_counter_ < params_.max_objects)
+  {
+    spawnObject();
+  }
+  else
+  {
+    recirculateObject();
+  }
+}
+
+void ConveyorSpawner::spawnObject()
 {
   ++object_counter_;
 
@@ -189,7 +224,7 @@ void ConveyorSpawner::spawnObject(const ros::TimerEvent& e)
   srv.request.robot_namespace = "gilbreth";
   srv.request.model_xml = createObjectURDF(obj->name, obj->mesh_resource);
   srv.request.initial_pose = obj->initial_pose;
-  srv.request.model_name = "object_" + std::to_string(object_counter_);
+  srv.request.model_name = generateObjectName(object_counter_);
 
   // Randomize the object's lateral spawn position
   // Create a new pseudo-random number between 0 and 1
@@ -241,6 +276,100 @@ void ConveyorSpawner::spawnObject(const ros::TimerEvent& e)
       msg.stamp = ros::Time::now();
       msg.seq = object_counter_;
       pub_.publish(msg);
+    }
+  }
+
+  ROS_DEBUG_STREAM(boost::str(boost::format("Spawned new object '%1%' with id '%2%'") % obj->name % srv.request.model_name));
+
+  // storing model name for tracking purposes
+  spawned_objects_map_.insert(std::make_pair(srv.request.model_name, obj->name));
+}
+
+void ConveyorSpawner::recirculateObject()
+{
+  if(inactive_objects_ids_.empty())
+  {
+    return; // no objects to recirculate yet
+  }
+
+  // randomize object choice from inactive list
+  int idx = rand() % inactive_objects_ids_.size();
+  auto obj_id = inactive_objects_ids_.begin();
+  std::advance(obj_id,idx);
+
+  // locating object from list
+  std::string obj_name = spawned_objects_map_[*obj_id];
+  std::vector<ObjectParameters>::iterator obj = std::find_if(params_.objects.begin(),
+                                                          params_.objects.end(),
+                                                          [&obj_name](const ObjectParameters& obj){
+                                                            return obj_name == obj.name; });
+
+  // create the set state request
+  gazebo_msgs::SetModelState srv;
+  gazebo_msgs::ModelState& ms = srv.request.model_state;
+  ms.model_name = *obj_id;
+  ms.pose = obj->initial_pose;
+  ms.reference_frame = params_.reference_frame;
+  tf::vector3TFToMsg(tf::Vector3(0,0,0),ms.twist.linear);
+  tf::vector3TFToMsg(tf::Vector3(0,0,0),ms.twist.angular);
+
+  // randomizing the y placement (along conveyor width)
+  double r_lpv = static_cast<double>(rand()) / static_cast<double>(RAND_MAX);
+  double& lpv = obj->lateral_placement_variance;
+  double lpv_delta = -lpv + 2.0*r_lpv*lpv;
+  ms.pose.position.y += lpv_delta;
+
+  // Randomize the object's yaw angle
+  double r_ypv = static_cast<double>(rand()) / static_cast<double>(RAND_MAX);
+  double& ypv = obj->yaw_placement_variance;
+  double ypv_delta = -ypv + 2.0*r_ypv*ypv;
+  tf::Quaternion q;
+  tf::quaternionMsgToTF(ms.pose.orientation, q);
+  tf::Quaternion dq = tf::createQuaternionFromRPY(0.0, 0.0, ypv_delta);
+  q *= dq;
+  tf::quaternionTFToMsg(q, ms.pose.orientation);
+
+  // Randomize the request call delay
+  double r_tv = static_cast<double>(rand()) / static_cast<double>(RAND_MAX);
+
+  ros::Duration time_var (r_tv * obj->spawn_timing_variance);
+  time_var.sleep();
+
+  // call the service
+  if(!set_state_client_.call(srv))
+  {
+    ROS_ERROR_STREAM(boost::str(boost::format("Failed to call the '%1%' service") % set_state_client_.getService()));
+    return;
+  }
+
+  if(!srv.response.success)
+  {
+    ROS_ERROR("The 'set_state' call failed");
+    return;
+  }
+
+  ROS_DEBUG_STREAM(boost::str(boost::format("Recirculated object '%1%' with id '%2%'") % obj->name % *obj_id));
+
+  // Publish which part was just recycled onto the conveyor
+  std_msgs::Header msg;
+  msg.frame_id = obj->name;
+  msg.stamp = ros::Time::now();
+  pub_.publish(msg);
+
+  inactive_objects_ids_.erase(obj_id);
+}
+
+void ConveyorSpawner::disposedObjectsCallback(const gazebo_msgs::ModelStatesConstPtr& msg)
+{
+  for(const auto& n: msg->name)
+  {
+    if(spawned_objects_map_.count(n))
+    {
+      inactive_objects_ids_.push_back(n);
+    }
+    else
+    {
+      ROS_WARN_STREAM(boost::str(boost::format("An unknown object '%1%' was received, ignoring ...") % n));
     }
   }
 }

--- a/gilbreth_gazebo/src/plugins/ConveyorBeltPlugin.cc
+++ b/gilbreth_gazebo/src/plugins/ConveyorBeltPlugin.cc
@@ -73,6 +73,15 @@ void ConveyorBeltPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
     return;
   }
 
+  if(_sdf->HasElement("max_belt_linear_vel"))
+  {
+    this->kMaxBeltLinVel = _sdf->Get<double>("max_belt_linear_vel");
+  }
+  else
+  {
+    gzdbg<<"Using default linear speed "<<this->kMaxBeltLinVel<<std::endl;
+  }
+
   // Set the point where the link will be moved to its starting pose.
   this->limit = this->joint->GetUpperLimit(0) - 0.6;
 

--- a/gilbreth_gazebo/src/plugins/ObjectDisposalPlugin.cc
+++ b/gilbreth_gazebo/src/plugins/ObjectDisposalPlugin.cc
@@ -18,8 +18,16 @@
 #include <limits>
 #include <string>
 #include <gazebo/transport/Node.hh>
-
+#include <boost/format.hpp>
 #include "gilbreth_gazebo/plugins/ObjectDisposalPlugin.hh"
+#include <eigen_conversions/eigen_msg.h>
+
+static const double WAIT_SERVICE_PERIOD = 5.0f;
+static const double ROS_QUEUE_TIMEOUT = 0.1;
+static const std::string DELETE_MODEL_SERVICE = "gazebo/delete_model";
+static const std::string SET_MODEL_STATE_SERVICE = "/gazebo/set_model_state";
+static const std::string DEFAULT_WORLD_FRAME_ID = "world";
+static const Eigen::Vector3d DISPOSE_LOCATION = Eigen::Vector3d(0,0,-10); // meters
 
 using namespace gazebo;
 GZ_REGISTER_MODEL_PLUGIN(ObjectDisposalPlugin)
@@ -60,6 +68,71 @@ void ObjectDisposalPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
   }
 
   this->disposalPose = _sdf->Get<math::Pose>("disposal_pose");
+
+  // connecting to ROS
+  GZ_ASSERT(ros::isInitialized(),"ROS is not initialized, can't subscribe to delete model server");
+
+  // setting up ROS connections
+  nh_.reset(new ros::NodeHandle());
+  delete_model_client_ = nh_->serviceClient<gazebo_msgs::DeleteModel>(DELETE_MODEL_SERVICE);
+  set_state_client_ = nh_->serviceClient<gazebo_msgs::SetModelState>(SET_MODEL_STATE_SERVICE);
+  GZ_ASSERT(delete_model_client_.waitForExistence(ros::Duration(WAIT_SERVICE_PERIOD)),
+            boost::str(boost::format("The service '%1%' was not found") % DELETE_MODEL_SERVICE).c_str());
+
+  // setting up info
+  world_frame_id_ = DEFAULT_WORLD_FRAME_ID;
+  gzmsg << boost::str(boost::format("World Frame ID '%1%'") % world_frame_id_)<< std::endl;
+
+  // ROS Thread setup
+  ros_queue_thread_ = std::thread(std::bind(&ObjectDisposalPlugin::processROSQueue,this));
+
+  gzmsg << boost::str(boost::format("Connected to service '%1%'") % DELETE_MODEL_SERVICE)<< std::endl;
+
+
+}
+
+void ObjectDisposalPlugin::processROSQueue()
+{
+  ros::Duration loop_pause(ROS_QUEUE_TIMEOUT);
+  while(nh_->ok())
+  {
+    deleteQueuedObjects();
+    loop_pause.sleep();
+  }
+}
+
+void ObjectDisposalPlugin::deleteQueuedObjects()
+{
+  gazebo_msgs::DeleteModel delete_model_srv;
+  gazebo_msgs::SetModelState set_state_srv;
+  while(!delete_model_queue_.empty())
+  {
+    std::string model_name = delete_model_queue_.front();
+
+    // moving model out of the way
+    gazebo_msgs::SetModelStateRequest& set_st_req = set_state_srv.request;
+    set_st_req.model_state.model_name = model_name;
+    Eigen::Affine3d pose = Eigen::Affine3d::Identity() * Eigen::Translation3d(DISPOSE_LOCATION);
+    tf::poseEigenToMsg(pose,set_st_req.model_state.pose);
+    set_st_req.model_state.reference_frame = world_frame_id_;
+
+    if(!set_state_client_.call(set_state_srv))
+    {
+      gzwarn<<boost::str(boost::format("Failed to move model '%1%' to discard location")% model_name)<<std::endl;
+    }
+
+    delete_model_srv.request.model_name = model_name;
+    if(delete_model_client_.call(delete_model_srv) && delete_model_srv.response.success)
+    {
+      gzdbg <<"Model '"<< delete_model_srv.request.model_name <<"' deleted"<<std::endl;
+    }
+    else
+    {
+      gzerr <<"Model deletion failed for '"<< delete_model_srv.request.model_name <<"'" <<std::endl;
+    }
+
+    delete_model_queue_.pop();
+  }
 }
 
 /////////////////////////////////////////////////
@@ -86,6 +159,7 @@ void ObjectDisposalPlugin::ActOnContactingModels()
   linkBoxMax.z = std::numeric_limits<double>::max();
   auto disposalBox = math::Box(linkBoxMin, linkBoxMax);
 
+
   for (auto model : this->contactingModels) {
     if (model) {
       bool removeModel = true;
@@ -108,9 +182,13 @@ void ObjectDisposalPlugin::ActOnContactingModels()
       }
       if (removeModel)
       {
-        gzdbg << "[" << this->model->GetName() << "] Removing model: " << model->GetName() << "\n";
-//        model->SetWorldPose(this->disposalPose);
-        world->RemoveModel(model->GetName());
+        // Queuing object for deletion
+        if(!delete_model_queue_.hasEntry(model->GetName() ))
+        {
+          gzdbg<<boost::str(boost::format("Adding %1% to deletion queue") %model->GetName() )<<std::endl;
+          delete_model_queue_.push(model->GetName());
+        }
+
       }
     }
   }

--- a/gilbreth_gazebo/src/plugins/ProximityRayPlugin.cc
+++ b/gilbreth_gazebo/src/plugins/ProximityRayPlugin.cc
@@ -165,7 +165,6 @@ bool ProximityRayPlugin::ProcessScan()
 
     if (objectDetected) {
         if (!this->objectDetected) {
-          gzdbg << "Object detected\n";
           stateChanged = true;
         }
         this->objectDetected = true;
@@ -173,7 +172,6 @@ bool ProximityRayPlugin::ProcessScan()
     else
     {
         if (this->objectDetected) {
-          gzdbg << "Object no longer detected\n";
           stateChanged = true;
         }
         this->objectDetected = false;

--- a/gilbreth_gazebo/src/plugins/ROSProximityRayPlugin.cc
+++ b/gilbreth_gazebo/src/plugins/ROSProximityRayPlugin.cc
@@ -104,7 +104,6 @@ void ROSProximityRayPlugin::OnNewLaserScans()
   this->statePub.publish(this->state_msg);
   if (stateChanged)
   {
-    gzdbg << this->parentSensor->Name() << ": change in sensor state\n";
     this->stateChangePub.publish(this->state_msg);
   }
 }

--- a/gilbreth_gazebo/worlds/gilbreth.world
+++ b/gilbreth_gazebo/worlds/gilbreth.world
@@ -9,8 +9,10 @@
     </gui>
 
     <physics type="ode">
+      <max_step_size>0.00625</max_step_size>
       <real_time_factor>1</real_time_factor>
-      <!--real_time_update_rate>0</real_time_update_rate-->
+      <real_time_update_rate>160</real_time_update_rate>
+      <gravity>0 0 -9.8</gravity>
     </physics>
 
     <!-- Disable shadows. -->

--- a/gilbreth_grasp_planning/scripts/test_robot_execution.py
+++ b/gilbreth_grasp_planning/scripts/test_robot_execution.py
@@ -23,6 +23,7 @@ GRIPPER_SERIVE_TOPIC='gilbreth/gripper/control'
 ARM_GROUP_NAME = 'robot_rail'
 MOVEIT_PLANNING_SERVICE = 'plan_kinematic_path'
 HOME_JOINT_POSE = 'robot_rail_home'
+NUM_GOAL_POSES = 1
 JOINT_RAND_FACTOR = [0.5] + [0.4]*6
 
 def waitForMoveGroup(wait_time = 10.0):
@@ -78,15 +79,15 @@ class RobotExecution:
       if robot_traj:
           
           robot_traj = curateTrajectory(robot_traj)
-          rospy.loginfo("Motion Plan Success: Current Pose ==> Waiting Pose.")
+          rospy.loginfo("Motion Planing Succeeded")
           if self.moveit_commander.execute(robot_traj):
             rospy.loginfo("Moved Robot to Target Pose")
             
           else:
-            rospy.logerr("Joint trajectory execution failed")
+            rospy.logerr("Trajectory execution failed")
             return False
       else:
-          rospy.logerr("Motion Plan Failed time: Current Pose ==> Waiting Pose.")
+          rospy.logerr("Motion Planning Failed.")
           return False
        
       return True
@@ -106,15 +107,16 @@ class RobotExecution:
       #return True  
       
       # Moving to each pose
-      joint_poses = createPoses(seed_joint_pose ,8)
-      for i, p in enumerate(joint_poses):
-        self.moveit_commander.set_start_state_to_current_state()
-        self.moveit_commander.set_joint_value_target(p)
-        
-        rospy.loginfo("Moving to position: %s"%(str(p) ))
-        
-        if not self.moveRobot():
-          return False
+      while not rospy.is_shutdown():
+          joint_poses = createPoses(seed_joint_pose ,NUM_GOAL_POSES)
+          for i, p in enumerate(joint_poses):
+            self.moveit_commander.set_start_state_to_current_state()
+            self.moveit_commander.set_joint_value_target(p)
+            
+            rospy.loginfo("Moving to position: %s"%(str(p) ))
+            
+            if not self.moveRobot():
+              return False
              
 
 def main(args):

--- a/gilbreth_moveit_config/launch/move_group.launch
+++ b/gilbreth_moveit_config/launch/move_group.launch
@@ -1,6 +1,11 @@
 <launch>
 
   <include file="$(find gilbreth_moveit_config)/launch/planning_context.launch" />
+  
+  <!--  Console output -->
+  <arg name="console_output" default="true"/>
+  <arg name="output_option" value="screen" if="$(arg console_output)"/>
+  <arg name="output_option" value="log" unless="$(arg console_output)"/>
 
   <!-- GDB Debug Option -->
   <arg name="debug" default="false" />
@@ -38,7 +43,8 @@
   </include>
 
   <!-- Start the actual move_group node/action server -->
-  <node name="move_group" launch-prefix="$(arg launch_prefix)" pkg="moveit_ros_move_group" type="move_group" respawn="false" output="screen" args="$(arg command_args)">
+  <node name="move_group" launch-prefix="$(arg launch_prefix)" pkg="moveit_ros_move_group" type="move_group"
+   respawn="false" output="$(arg output_option)" args="$(arg command_args)">
     <!-- Set the display variable, in case OpenGL code is used internally -->
     <env name="DISPLAY" value="$(optenv DISPLAY :0)" />
 

--- a/gilbreth_support/urdf/robot_system/robot_system.xacro
+++ b/gilbreth_support/urdf/robot_system/robot_system.xacro
@@ -9,7 +9,7 @@
   <xacro:linear_actuator_urdf prefix="${linear_actuator_prefix}"/>
 
   <xacro:include filename="$(find gilbreth_support)/urdf/linear_actuator/linear_actuator.gazebo.xacro"/>
-  <xacro:linear_actuator_gazebo prefix="${linear_actuator_prefix}" joint_interface="PositionJointInterface"/>
+  <xacro:linear_actuator_gazebo prefix="${linear_actuator_prefix}" joint_interface="hardware_interface/PositionJointInterface"/>
 
   <!-- Robot -->
   <xacro:include filename="$(find ur_description)/urdf/ur10.urdf.xacro"/>


### PR DESCRIPTION
This PR specifies the ODE simulation parameters so that the RTF (real time factor) stays at 1.0.
This change was tested with a total of 40 objects spawned withing 0.5 seconds of each other and with the robot moving to randomized joint poses at all times.  
The RTF stayed at 1.0 when collisions between objects rarely occurred (conveyor belt moving fast power=50.0).  
However, the RTF declined to an average of 0.94 when the conveyor speed was reduced (power=30.0) thus allowing for object collisions to happen very frequently.  My guess is that the simulation had to process more contacts (ODE represents collisions with contacts afaik) that resulted from the collisions.

When the physics parameters are not specified then the simulation will try to run as fast as possible, more on these parameters can be found [here](http://gazebosim.org/tutorials?tut=modifying_world)

This PR contains the changes from PR #43 so that one should be merged first.
@lianjunli  or @alex07zzz  please review.