### PR TITLE
gilbreth_environment.launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,9 @@ The project is based on Ubuntu 16.04, ROS Kinect, gazebo 7.0, wstool and catkin 
 
 	```
   	roscd gilbreth_gazebo
-  	source scripts/env_setup.bash
-	roslaunch gilbreth_gazebo gilbreth.launch rviz:=false
+	roslaunch gilbreth_gazebo gilbreth_environment.launch rviz:=false
 	```
 
-  	- The **source scripts/env_setup.bash** command sets up environment variables needed
-  	by the gazebo simulator.  
     - Use "rviz:=true" to show rviz
   	
 1. Activate the gripper:


### PR DESCRIPTION
There is no file called gilbreth.launch in the gilbreth_gazebo directory. There is however a file called gilbreth_environment.launch which seems to bring up the desired gazebo environment. 

Additionally, the env_setup.bash script does not seem to be necessary to run the subsequent commands.

My notes on the installation process can be found here: 
[NotesGilbreth.pdf](https://github.com/swri-robotics/gilbreth/files/2214053/NotesGilbreth.pdf)
